### PR TITLE
Update stylings on dashboard

### DIFF
--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -7,7 +7,15 @@ import Grid from "@mui/material/Grid";
 export default function Dashboard() {
   return (
     <>
-      <Grid container spacing={4} sx={{ marginTop: 10, paddingLeft: 10, paddingRight: 10 }}>
+      <Grid
+        container
+        spacing={4}
+        sx={{
+          marginTop: 10,
+          paddingLeft: 5,
+          paddingRight: 5
+        }}
+      >
         <Grid item xs={12} md={7}>
           <Challenges title={'My Challenges'} />
           <Challenges title={'Browse Challenges'} />

--- a/src/components/Challenges.jsx
+++ b/src/components/Challenges.jsx
@@ -1,14 +1,10 @@
 // import axios from "axios";
 
 import Grid from "@mui/material/Grid";
-import ImageList from "@mui/material/ImageList";
-import ImageListItem from "@mui/material/ImageListItem";
-import ImageListItemBar from "@mui/material/ImageListItemBar";
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
+import { ImageList, ImageListItem, ImageListItemBar, Box, Typography } from "@mui/material";
+import { styled } from '@mui/system';
 import Link from "next/link";
 import { useChallengeContext } from "../../ChallengeContext.js"
-
 
 // const BACKENDURL = "https://shy-bye-app.fly.dev";
 
@@ -36,6 +32,15 @@ export default function Challenges(props) {
 
   const { title } = props;
   const { setData } = useChallengeContext()
+
+  const EllipsisText = styled('div')({
+    display: '-webkit-box',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 3,
+    whiteSpace: 'normal',
+  });
 
   return (
     <Grid item>
@@ -90,12 +95,11 @@ export default function Challenges(props) {
                     borderBottomLeftRadius: 3,
                     borderBottomRightRadius: 3,
                     color: '#000',
-                    display: 'flex',
                     height: 90,
-                    justifyContent: 'center',
-                    padding: 2
+                    padding: 2,
                   }}
-                  title={<div>{item.challengeName}</div>}
+
+                  title={<EllipsisText>{item.challengeName}</EllipsisText>}
                   position="below"
                 />
               </ImageListItem>

--- a/src/components/Challenges.jsx
+++ b/src/components/Challenges.jsx
@@ -49,7 +49,7 @@ export default function Challenges(props) {
           {title}
         </Typography>
       </ Box>
-      <Grid xs={12}>
+      <Grid item>
         <ImageList
           sx={{ maxHeight: 600 }} cols={3}
         >

--- a/src/components/NextAchievement.jsx
+++ b/src/components/NextAchievement.jsx
@@ -10,11 +10,7 @@ const Progress = () => {
       item
       xs={12}
       md={12}
-      sx={{
-        minWidth: 420,
-        minHeight: 240,
-        marginTop: 10
-      }}
+      sx={{ marginTop: 10 }}
     >
       <AchievementContainer>
         <AchievementBox>
@@ -57,7 +53,6 @@ const TitleBox = styled.div`
   display: flex;
   justify-content: space-around;
   margin-top: 20px;
-  min-width: 420px;
 `;
 
 const MedalBox = styled.div`
@@ -65,7 +60,7 @@ const MedalBox = styled.div`
   height: 210px;
   justify-content: center;
   margin-top: 20px;
-  width: 420px;
+  min-width: 400px;
 `;
 
 const ViewAllLink = styled.div`

--- a/src/components/Progress.jsx
+++ b/src/components/Progress.jsx
@@ -10,8 +10,8 @@ const Progress = () => {
       xs={12}
       md={12}
       sx={{
-        minWidth: 420,
-        minHeight: 510,
+        maxWidth: 420,
+        maxHeight: 510,
       }}
     >
       <ProgressContainer>


### PR DESCRIPTION
## Description ✏️ 
We needed to apply style changes for the small screen.

## Type of change ⭐ 
Before:
Card size weren't consistent:
<img width="416" alt="Screenshot 2023-11-27 at 1 17 25 PM" src="https://github.com/shybyeapp/shybye-web/assets/60206746/9029d29b-4b64-4c49-a80a-2482a802c060">

Challenge descriptions were overflowing:
<img width="399" alt="Screenshot 2023-11-27 at 1 14 18 PM" src="https://github.com/shybyeapp/shybye-web/assets/60206746/65445b9b-4cb5-4c3d-bee7-98fb8d8bf4f2">

After:
<img width="443" alt="Screenshot 2023-11-27 at 1 15 29 PM" src="https://github.com/shybyeapp/shybye-web/assets/60206746/0b1662eb-3fd9-4dc7-aed8-e45347ba4463">

## Notes 📔
NA
## Card 🎫
NA